### PR TITLE
Use `ThreadLocalProvenanceTracker`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy-agent -->
 
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.42.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>nz.ac.wgtn.veracity.approv</groupId>
             <artifactId>java-binding</artifactId>
             <version>0.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,6 @@
         <!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy-agent -->
 
         <dependency>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>3.42.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>nz.ac.wgtn.veracity.approv</groupId>
             <artifactId>java-binding</artifactId>
             <version>0.0.2</version>

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -1,8 +1,8 @@
 package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
 
 import nz.ac.wgtn.veracity.provenance.injector.model.Invocation;
-import nz.ac.wgtn.veracity.provenance.injector.tracker.GlobalProvenanceTracker;
 import nz.ac.wgtn.veracity.provenance.injector.tracker.ProvenanceTracker;
+import nz.ac.wgtn.veracity.provenance.injector.tracker.ThreadLocalProvenanceTracker;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
@@ -55,7 +55,7 @@ public class ProvenanceAgent {
      */
     private static void install(Instrumentation instrumentation) {
         // Construct cache to be used by instrumentation classes
-        tracker = new GlobalProvenanceTracker();
+        tracker = new ThreadLocalProvenanceTracker<Invocation>();
         AssociationCache cache = new AssociationCache(tracker);
         AssociationCacheRegistry.registerCache(cache);
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -1,6 +1,8 @@
 package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
 
+import nz.ac.wgtn.veracity.provenance.injector.model.Invocation;
 import nz.ac.wgtn.veracity.provenance.injector.tracker.GlobalProvenanceTracker;
+import nz.ac.wgtn.veracity.provenance.injector.tracker.ProvenanceTracker;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 
@@ -20,6 +22,8 @@ public class ProvenanceAgent {
             "java/nio"
 //            "java/sql"
     );
+
+    private static ProvenanceTracker<Invocation> tracker;
 
     private ProvenanceAgent() {
 
@@ -51,7 +55,8 @@ public class ProvenanceAgent {
      */
     private static void install(Instrumentation instrumentation) {
         // Construct cache to be used by instrumentation classes
-        AssociationCache cache = new AssociationCache(new GlobalProvenanceTracker());
+        tracker = new GlobalProvenanceTracker();
+        AssociationCache cache = new AssociationCache(tracker);
         AssociationCacheRegistry.registerCache(cache);
 
         instrumentation.addTransformer(new ClassFileTransformer() {
@@ -75,5 +80,9 @@ public class ProvenanceAgent {
                 return classfileBuffer;
             }
         }, true);
+    }
+
+    public static ProvenanceTracker<Invocation> getProvenanceTracker() {
+        return tracker;
     }
 }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ProvenanceTracker.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ProvenanceTracker.java
@@ -8,6 +8,8 @@ import java.util.List;
  */
 public interface ProvenanceTracker <T> {
 
+    public static final String NO_ACTIVE_REQUEST_ID = "NO_ACTIVE_REQUEST";
+
     /**
      * Starts tracking, and returns a unique session id.
      * This id can be used to pick up provenance records.

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
@@ -1,7 +1,5 @@
 package nz.ac.wgtn.veracity.provenance.injector.tracker;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -18,14 +16,14 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
 
     // Class invariants:
-    // - noActiveRequestTrackedData.get() and trackedData.get() are never null
+    // - noActiveRequestTrackedData.get() and trackedData.get() are never null (@NonNull omitted to minimise deps)
     // - trackedData:
     //     - initially, and after calling finish(), references noActiveRequestTrackedData's contents
     //     - start() allocates a new list
     // - id.get() == null iff trackedData.get() == noActiveRequestTrackedData.get(). Indicates "outside of any request".
 
-    private final ThreadLocal<@NonNull List<T>> noActiveRequestTrackedData = ThreadLocal.withInitial(ArrayList::new);
-    private final ThreadLocal<@NonNull List<T>> trackedData = ThreadLocal.withInitial(noActiveRequestTrackedData::get);
+    private final ThreadLocal</*@NonNull*/ List<T>> noActiveRequestTrackedData = ThreadLocal.withInitial(ArrayList::new);
+    private final ThreadLocal</*@NonNull*/ List<T>> trackedData = ThreadLocal.withInitial(noActiveRequestTrackedData::get);
     private final ThreadLocal<String> id = new ThreadLocal<>();
     private static final AtomicLong ID_GENERATOR = new AtomicLong();
     private final Map<String,List<T>> outbox = Collections.synchronizedMap(new LinkedHashMap<>());

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
@@ -1,5 +1,7 @@
 package nz.ac.wgtn.veracity.provenance.injector.tracker;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -9,29 +11,62 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Describes a datastore that can be used to track (meta)data of a computation collected by an instrumentation.
+ * Tracked invocations that occur outside of any request ({@link #start()}-{@link #finish()} pair) can be
+ * picked up using the bucket ID {@link #NO_ACTIVE_REQUEST_ID} -- see {@link #finish()}.
  * @param <T>  -- the kind of data that is being collected
  */
 public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
 
+    // Class invariants:
+    // - noActiveRequestTrackedData.get() and trackedData.get() are never null
+    // - trackedData:
+    //     - initially, and after calling finish(), references noActiveRequestTrackedData's contents
+    //     - start() allocates a new list
+    // - id.get() == null iff trackedData.get() == noActiveRequestTrackedData.get(). Indicates "outside of any request".
 
-    private final ThreadLocal<List<T>> trackedData = new ThreadLocal<>();
+    private final ThreadLocal<@NonNull List<T>> noActiveRequestTrackedData = ThreadLocal.withInitial(ArrayList::new);
+    private final ThreadLocal<@NonNull List<T>> trackedData = ThreadLocal.withInitial(noActiveRequestTrackedData::get);
     private final ThreadLocal<String> id = new ThreadLocal<>();
     private static final AtomicLong ID_GENERATOR = new AtomicLong();
     private final Map<String,List<T>> outbox = Collections.synchronizedMap(new LinkedHashMap<>());
 
     public String start() {
+        if (id.get() != null) {
+            throw new RuntimeException("ThreadLocalProvenanceTracker.start() called a second time on thread without intervening finish()");
+        }
+
         String generatedId = "" + ID_GENERATOR.incrementAndGet();
         this.id.set(generatedId);
         this.trackedData.set(new ArrayList<>());
         return generatedId;
     }
 
+    /**
+     * Call once per {@link #start()} call to make in-request tracked invocations available for {@link #pickup(String)}.
+     * Also, for any thread in which tracked invocations occur outside of any request
+     * ({@link #start()}-{@link #finish()} pair), call at most once to make those invocations available for
+     * {@link #pickup(String)} under the ID {@link #NO_ACTIVE_REQUEST_ID}.
+     * Note: For these non-request invocations, calling {@code { finish(); pickup(); cull(); }}
+     * must be synchronised across threads.
+     * TODO: There is currently no way to determine which threads have outstanding non-request invocations.
+     */
     public void finish() {
-        this.outbox.put(id.get(),Collections.unmodifiableList(trackedData.get()));
-        this.trackedData.remove();
+        this.outbox.put(getNiceId(), Collections.unmodifiableList(trackedData.get()));
+        if (trackedData.get() == noActiveRequestTrackedData.get()) {
+            // We are outside of any request.
+            noActiveRequestTrackedData.set(new ArrayList<>());  // Don't touch the list in the outbox
+        }
+        trackedData.set(noActiveRequestTrackedData.get());
         this.id.remove();
     }
 
+    /**
+     * Called from instrumented code at any time.
+     * Note: There is no guarantee that {@link #start()} has been called beforehand.
+     * E.g., tracked invocations may occur before or between requests. All such invocations will be added to the
+     * {@link #NO_ACTIVE_REQUEST_ID} bucket.
+     * @param data
+     */
     public void track(T data) {
         trackedData.get().add(data);
     }
@@ -52,4 +87,7 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
         return outbox.remove(id)!=null;
     }
 
+    private String getNiceId() {
+        return id.get() != null ? id.get() : NO_ACTIVE_REQUEST_ID;
+    }
 }


### PR DESCRIPTION
Resolves #21.

Also makes out-of-request tracked invocations (those that happen before, in between, or after any `start()`-`finish()` pair) available under the bucket ID `NO_ACTIVE_REQUEST`, even if they occur on the same thread as in-request tracked invocations. These can be made available to `pickup()` with an unpaired `finish()` call on the thread where the invocation happened (though there's currently no way to enumerate the list of all such threads).

Also throw an exception if `start()` is called twice on the same thread with no intervening `finish()` -- this indicates a bug.

Will do some testing with the movie demo before merging, and probably add some more tests.