### PR TITLE
Add script to enable provenance collection for Spring Boot apps

### DIFF
--- a/provenancify-spring-boot-app.sh
+++ b/provenancify-spring-boot-app.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ $# = 0 ]; then
+  echo "Must specify the app jar." >&2
+  exit 1
+fi
+
+APPJARPATH=$(realpath "$1")
+PROVAGENTJARPATH=$(realpath target/provenance-agent.jar)
+EXPLODEDIR=$(mktemp -d)
+
+echo
+
+# Explode the provenance agent jar
+( cd "$EXPLODEDIR" && jar xf "$PROVAGENTJARPATH" && jar uf "$APPJARPATH" * )
+
+#rm -r "$EXPLODEDIR"

--- a/provenancify-spring-boot-app.sh
+++ b/provenancify-spring-boot-app.sh
@@ -9,9 +9,24 @@ APPJARPATH=$(realpath "$1")
 PROVAGENTJARPATH=$(realpath target/provenance-agent.jar)
 EXPLODEDIR=$(mktemp -d)
 
-echo
+echo "APPJARPATH=$APPJARPATH"
+echo "PROVAGENTJARPATH=$PROVAGENTJARPATH"
+echo "EXPLODEDIR=$EXPLODEDIR"
 
 # Explode the provenance agent jar
-( cd "$EXPLODEDIR" && jar xf "$PROVAGENTJARPATH" && jar uf "$APPJARPATH" * )
-
-#rm -r "$EXPLODEDIR"
+(
+  cd "$EXPLODEDIR" &&
+  jar xf "$PROVAGENTJARPATH" &&
+  rm -f META-INF/MANIFEST.MF &&
+  jar xf "$APPJARPATH" META-INF/MANIFEST.MF &&    # jar ...M should make this step unnecessary, but it doesn't
+  jar ufM "$APPJARPATH" * &&
+  (
+    echo "Can-Redefine-Classes: true" &&
+    echo "Can-Retransform-Classes: true" &&
+    echo "Launcher-Agent-Class: nz.ac.wgtn.veracity.provenance.injector.instrument" &&
+    echo " ation.ProvenanceAgent"
+  ) > extra-manifest-entries &&
+  jar ufm "$APPJARPATH" extra-manifest-entries
+) &&
+rm -r "$EXPLODEDIR" &&
+echo DONE

--- a/provenancify-spring-boot-app.sh
+++ b/provenancify-spring-boot-app.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ $# = 0 ]; then
-  echo "Must specify the app jar." >&2
+if [ $# = 0 ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 path/to/my-spring-boot-app.war" >&2
   exit 1
 fi
 
@@ -13,13 +13,12 @@ echo "APPJARPATH=$APPJARPATH"
 echo "PROVAGENTJARPATH=$PROVAGENTJARPATH"
 echo "EXPLODEDIR=$EXPLODEDIR"
 
-# Explode the provenance agent jar
 (
   cd "$EXPLODEDIR" &&
   jar xf "$PROVAGENTJARPATH" &&
   rm -f META-INF/MANIFEST.MF &&
-  jar xf "$APPJARPATH" META-INF/MANIFEST.MF &&    # jar ...M should make this step unnecessary, but it doesn't
-  jar ufM "$APPJARPATH" * &&
+  jar xf "$APPJARPATH" META-INF/MANIFEST.MF &&
+  jar ufM "$APPJARPATH" * &&    # jar ...M should make the previous step unnecessary, but it doesn't
   (
     echo "Can-Redefine-Classes: true" &&
     echo "Can-Retransform-Classes: true" &&


### PR DESCRIPTION
Modifies a Spring Boot web app in a `.war` or `.jar` file to enable the provenance injector to run automatically, without the need to specify `-javaagent:...` on the `java` command line.

- Adds "exploded" contents of `provenance-agent.jar` directly to the web app jar
- Appends some lines to `META-INF/MANIFEST.MF` (notably `Launcher-Agent-Class`) to enable the agent to run automatically

Tested on the movie demo app.

For now, the Spring Boot app needs to contain its own mechanisms for turning on provenance collection for each request (probably using an `Interceptor`), and picking up provenance records (probably using a `@Controller` component). In light of [this](https://github.com/veracitylab/provenance-injector/issues/19#issuecomment-1993380316), this logic will eventually be moved inside this repo.