### PR TITLE
WIP movie demo integration: Ignore `URLClassLoader` and our own packages, debug logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nz.ac.wgtn.veracity</groupId>
     <artifactId>provenance-injector</artifactId>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCache.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCache.java
@@ -31,6 +31,7 @@ class AssociationCache {
     }
 
     void cacheInvocation(Invocation invocation, Object target) {
+//        System.out.println("AssociationCache.cacheInvocation(invocation=" + invocation + ", target=" + target + ") called.");   //DEBUG
         int targetIdent = System.identityHashCode(target);
 
         if (targetIdent != 0 && targetsToEntitiesCache.containsKey(targetIdent)) {
@@ -39,6 +40,7 @@ class AssociationCache {
         }
 
         invocationCache.add(invocation);
+//        System.out.println("AssociationCache.cacheInvocation() about to call externalTracker.track().");   //DEBUG
         externalTracker.track(invocation);
     }
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCache.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCache.java
@@ -11,7 +11,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-class AssociationCache {
+public class AssociationCache {
 
     private final ProvenanceTracker<Invocation> externalTracker;
     private final Set<Invocation> invocationCache;
@@ -21,7 +21,7 @@ class AssociationCache {
     private final Map<String, Object> taintedTargetsCache;
 
 
-    AssociationCache(ProvenanceTracker<Invocation> tracker) {
+    public AssociationCache(ProvenanceTracker<Invocation> tracker) {
         this.externalTracker = tracker;
         this.invocationCache = Collections.synchronizedSet(new LinkedHashSet<>());
         this.entityCache = Collections.synchronizedMap(new LinkedHashMap<>());
@@ -44,7 +44,7 @@ class AssociationCache {
         externalTracker.track(invocation);
     }
 
-    void cacheEntity(String entityTaint, Entity entity, Object target) {
+    public void cacheEntity(String entityTaint, Entity entity, Object target) {
         if (entity != null && !taintedTargetsCache.containsKey(entityTaint)) {
             int identity = System.identityHashCode(entity.getValue());
             entityCache.put(identity, entity);
@@ -83,11 +83,11 @@ class AssociationCache {
         }
     }
 
-    Set<Invocation> getInvocationCache() {
+    public Set<Invocation> getInvocationCache() {
         return Set.copyOf(invocationCache);
     }
 
-    Set<Entity> getEntityCache() {
+    public Set<Entity> getEntityCache() {
         return Set.copyOf(entityCache.values());
     }
 
@@ -95,7 +95,7 @@ class AssociationCache {
         return Map.copyOf(entityCache);
     }
 
-    void clear() {
+    public void clear() {
         invocationCache.clear();
         entityCache.clear();
         targetsToEntitiesCache.clear();

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCacheRegistry.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/AssociationCacheRegistry.java
@@ -1,6 +1,6 @@
 package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
 
-class AssociationCacheRegistry {
+public class AssociationCacheRegistry {
 
     private static volatile AssociationCache cache = null;
 
@@ -10,7 +10,7 @@ class AssociationCacheRegistry {
         cache = newCache;
     }
 
-    static AssociationCache getCache() {
+    public static AssociationCache getCache() {
         if (cache == null) {
             throw new IllegalStateException("No cache is registered");
         }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
@@ -76,7 +76,7 @@ public class CallSiteVisitor extends ClassVisitor {
             });
         }
 
-        return new InvocationTrackingInjector(visitor, this.currentClass, captureReturnValue.get(), taint);
+        return new InvocationTrackingInjector(visitor, this.currentClass, name, descriptor, captureReturnValue.get(), taint);
     }
 
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
@@ -87,7 +87,7 @@ public class CallSiteVisitor extends ClassVisitor {
      */
     public static void recordParameter(String entityType, String identifier, Object param) {
         System.out.println("recordParameter(entityType=" + entityType + ", identifier=" + identifier + ", param=" + param + (param == null ? "" : " (type: " + param.getClass() + ")") + ")! Stacktrace:");   //DEBUG
-        new Throwable().printStackTrace();  //DEBUG
+        new Throwable().printStackTrace(System.out);  //DEBUG
         System.out.println("recordParameter(): end of stacktrace."); //DEBUG
         Entity entity = Entity.create(entityType, param);
         AssociationCacheRegistry.getCache().cacheEntity(identifier, entity, null);

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
@@ -46,6 +46,9 @@ public class CallSiteVisitor extends ClassVisitor {
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         super.visit(version, access, name, signature, superName, interfaces);
         this.currentClass = name;
+        if (name.startsWith("nz")) {
+            System.out.println("CallSiteVisitor: visiting class " + name);  //DEBUG
+        }
     }
 
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
@@ -13,6 +13,7 @@ import org.objectweb.asm.Type;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static nz.ac.wgtn.veracity.provenance.injector.util.Consts.C_BOOL;
 import static nz.ac.wgtn.veracity.provenance.injector.util.Consts.C_BYTE;
@@ -46,7 +47,7 @@ public class CallSiteVisitor extends ClassVisitor {
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         super.visit(version, access, name, signature, superName, interfaces);
         this.currentClass = name;
-        if (name.startsWith("nz")) {
+        if (name.startsWith("nz") || name.endsWith("/URL")) {
             System.out.println("CallSiteVisitor: visiting class " + name);  //DEBUG
         }
     }
@@ -59,6 +60,10 @@ public class CallSiteVisitor extends ClassVisitor {
         AtomicBoolean captureReturnValue = new AtomicBoolean(false);
 
         Set<EntityCreation> createEntities = Bindings.getEntityCreations(this.currentClass.replace('/', '.'), name, descriptor);
+
+        if (currentClass.startsWith("nz") || currentClass.endsWith("/URL")) {
+            System.out.printf("visitMethod(name=%s, descriptor=%s) in class %s. createEntities=[%s].%n", name, descriptor, currentClass, createEntities.stream().map((EntityCreation ec) -> ec.getEntity().toString()).collect(Collectors.joining(", ")));
+        }
 
         if (!createEntities.isEmpty()) {
             createEntities.forEach(entity -> {

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/CallSiteVisitor.java
@@ -71,6 +71,7 @@ public class CallSiteVisitor extends ClassVisitor {
                     int varTableIndex = entity.getRefIndex();
                     Type arg = argTypes[varTableIndex];
                     boxAndStore(visitor, entity, arg, varTableIndex + offset, taint);
+                    System.out.printf("Inserted call to recordParameter() at start of %s.%s (descriptor: %s).%n", currentClass, name, descriptor);
                 }
             });
         }
@@ -85,6 +86,9 @@ public class CallSiteVisitor extends ClassVisitor {
      * @param param recorded parameter
      */
     public static void recordParameter(String entityType, String identifier, Object param) {
+        System.out.println("recordParameter(entityType=" + entityType + ", identifier=" + identifier + ", param=" + param + (param == null ? "" : " (type: " + param.getClass() + ")") + ")! Stacktrace:");   //DEBUG
+        new Throwable().printStackTrace();  //DEBUG
+        System.out.println("recordParameter(): end of stacktrace."); //DEBUG
         Entity entity = Entity.create(entityType, param);
         AssociationCacheRegistry.getCache().cacheEntity(identifier, entity, null);
     }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
@@ -41,14 +41,18 @@ public class InvocationTrackingInjector extends MethodVisitor {
     private static final String RECORD_DESCRIPTOR = "(Ljava/lang/Object;Ljava/lang/String;)V";
     private final MethodVisitor visitor;
     private final String callingClass;
+    private final String ownMethodName;     //DEBUG
+    private final String ownMethodDescriptor;   //DEBUG
     private final boolean trackMethodReturn;
 
     private final String taint;
 
-    public InvocationTrackingInjector(MethodVisitor visitor, String callingClass, boolean trackMethodReturn, String taint) {
+    public InvocationTrackingInjector(MethodVisitor visitor, String callingClass, String ownMethodName, String ownMethodDescriptor, boolean trackMethodReturn, String taint) {
         super(Opcodes.ASM9, visitor);
         this.visitor = visitor;
         this.callingClass = callingClass;
+        this.ownMethodName = ownMethodName;
+        this.ownMethodDescriptor = ownMethodDescriptor;
         this.trackMethodReturn = trackMethodReturn;
         this.taint = taint;
 
@@ -75,7 +79,7 @@ public class InvocationTrackingInjector extends MethodVisitor {
         boolean debugLog = false;
         if (name.endsWith("dummyStaticMethod")) {
             debugLog = true;
-            System.out.println("Visiting method instruction in dummyStaticMethod()! owner=" + owner + ", callingClass=" + callingClass);
+            System.out.println("Visiting method call instruction in dummyStaticMethod()! Call is to " + owner + "." + name + "() with desc " + descriptor + ", callingClass=" + callingClass);
         }
         super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
         Set<URI> activities = Bindings.getActivities(owner.replace('/', '.'), name, descriptor);
@@ -97,7 +101,7 @@ public class InvocationTrackingInjector extends MethodVisitor {
 
             if (!returnType.equals(Type.VOID_TYPE) && !entities.isEmpty()) {
 
-                System.out.printf("DEBUG: Called method: %s%n", descriptor);
+                System.out.printf("DEBUG: Called method: %s (desc: %s)%n", name, descriptor);
                 System.out.printf("DEBUG: Non void type of: %s%n", returnType);
 
                 boxReturnValue(visitor, returnType);
@@ -177,6 +181,8 @@ public class InvocationTrackingInjector extends MethodVisitor {
                 "(Ljava/lang/Object;Ljava/lang/String;)V",
                 false
         );
+
+        System.out.printf("Inserted call to captureTarget() before RETURN inside %s.%s (descriptor: %s).%n", callingClass, ownMethodName, ownMethodDescriptor);
     }
 
     private void boxReturnValue(MethodVisitor visitor, Type returnType) {
@@ -246,7 +252,7 @@ public class InvocationTrackingInjector extends MethodVisitor {
      */
     public static void captureTarget(Object target, String taint) {
         AssociationCacheRegistry.getCache().cacheEntity(taint, null, target);
-        System.out.printf("DEBUG: Got target of type: %s%n", target.getClass().getName());
-        System.out.printf("DEBUG: Return value is: %s%n", target);
+        System.out.printf("DEBUG: captureTarget(): Got target of type: %s%n", target.getClass().getName());
+        System.out.printf("DEBUG: captureTarget(): Return value is: %s%n", target);
     }
 }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
@@ -223,7 +223,9 @@ public class InvocationTrackingInjector extends MethodVisitor {
      * invocation tracker
      */
     public static void recordActivity(Object capturedReturn, String activityTypes) {
-        System.out.println("recordActivity(capturedReturn=" + capturedReturn + ", activityTypes=" + activityTypes + "!");   //DEBUG
+        System.out.println("recordActivity(capturedReturn=" + capturedReturn + ", activityTypes=" + activityTypes + ")! Stacktrace:");   //DEBUG
+        new Throwable().printStackTrace();  //DEBUG
+        System.out.println("recordActivity(): end of stacktrace."); //DEBUG
         List<Activity> activities = Arrays.stream(activityTypes.split(";"))
                 .map(Activity::create)
                 .collect(Collectors.toList());

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
@@ -51,6 +51,10 @@ public class InvocationTrackingInjector extends MethodVisitor {
         this.callingClass = callingClass;
         this.trackMethodReturn = trackMethodReturn;
         this.taint = taint;
+
+        if (trackMethodReturn) {
+            System.out.println("InvocationTrackingInjector ctor called with trackMethodReturn=" + trackMethodReturn + " for class " + callingClass + "!");  //DEBUG
+        }
     }
 
     /**
@@ -223,7 +227,7 @@ public class InvocationTrackingInjector extends MethodVisitor {
      * invocation tracker
      */
     public static void recordActivity(Object capturedReturn, String activityTypes) {
-        System.out.println("recordActivity(capturedReturn=" + capturedReturn + ", activityTypes=" + activityTypes + ")! Stacktrace:");   //DEBUG
+        System.out.println("recordActivity(capturedReturn=" + capturedReturn + (capturedReturn == null ? "" : " (type: " + capturedReturn.getClass() + ")") + ", activityTypes=" + activityTypes + ")! Stacktrace:");   //DEBUG
         new Throwable().printStackTrace();  //DEBUG
         System.out.println("recordActivity(): end of stacktrace."); //DEBUG
         List<Activity> activities = Arrays.stream(activityTypes.split(";"))

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/InvocationTrackingInjector.java
@@ -228,7 +228,7 @@ public class InvocationTrackingInjector extends MethodVisitor {
      */
     public static void recordActivity(Object capturedReturn, String activityTypes) {
         System.out.println("recordActivity(capturedReturn=" + capturedReturn + (capturedReturn == null ? "" : " (type: " + capturedReturn.getClass() + ")") + ", activityTypes=" + activityTypes + ")! Stacktrace:");   //DEBUG
-        new Throwable().printStackTrace();  //DEBUG
+        new Throwable().printStackTrace(System.out);  //DEBUG
         System.out.println("recordActivity(): end of stacktrace."); //DEBUG
         List<Activity> activities = Arrays.stream(activityTypes.split(";"))
                 .map(Activity::create)

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -19,7 +19,13 @@ public class ProvenanceAgent {
             "java/lang/",
             "java/util/",
             "java/security/",
-            "java/nio"
+            "java/nio",
+            "nz/ac/wgtn/veracity/approv/jbind/",
+            "nz/ac/wgtn/veracity/provenance/injector/instrumentation/",
+            "nz/ac/wgtn/veracity/provenance/injector/model/",
+            "nz/ac/wgtn/veracity/provenance/injector/serializer/",
+            "nz/ac/wgtn/veracity/provenance/injector/tracker/",
+            "nz/ac/wgtn/veracity/provenance/injector/util/"
 //            "java/sql"
     );
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -73,6 +73,17 @@ public class ProvenanceAgent {
         AssociationCache cache = new AssociationCache(tracker);
         AssociationCacheRegistry.registerCache(cache);
 
+        //DEBUG
+        System.out.println("List of already-loaded classes at agent start time:");
+        Class[] alreadyLoadedClasses = instrumentation.getAllLoadedClasses();
+        for (Class c: alreadyLoadedClasses) {
+//            System.out.println("Already loaded class: " + c.getName() + " (loader: " + c.getClassLoader().getName() + ")");
+            String classLoaderName = c.getClassLoader() == null ? "null" : c.getClassLoader().getName();
+            System.out.println("Already loaded class: " + c.getName() + " (loader: " + classLoaderName + ")");
+//            System.out.println("Already loaded class: " + c.getName());
+        }
+        System.out.println("End of list of already-loaded classes at agent start time.");
+
         instrumentation.addTransformer(new ClassFileTransformer() {
             @Override
             public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -76,6 +76,7 @@ public class ProvenanceAgent {
         instrumentation.addTransformer(new ClassFileTransformer() {
             @Override
             public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+                System.out.printf("transform(loader=%s, className=%s, %s) called.%n", loader.getName(), className, classBeingRedefined == null ? "LOAD" : "REDEFINITION!");
                 if(ignorePackages.stream().parallel().anyMatch(className::startsWith)) {
                     return null;
                 }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -25,7 +25,8 @@ public class ProvenanceAgent {
             "nz/ac/wgtn/veracity/provenance/injector/model/",
             "nz/ac/wgtn/veracity/provenance/injector/serializer/",
             "nz/ac/wgtn/veracity/provenance/injector/tracker/",
-            "nz/ac/wgtn/veracity/provenance/injector/util/"
+            "nz/ac/wgtn/veracity/provenance/injector/util/",
+            "java/net/URLClassLoader"
 //            "java/sql"
     );
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -79,8 +79,7 @@ public class ProvenanceAgent {
         for (Class c: alreadyLoadedClasses) {
 //            System.out.println("Already loaded class: " + c.getName() + " (loader: " + c.getClassLoader().getName() + ")");
             String classLoaderName = c.getClassLoader() == null ? "null" : c.getClassLoader().getName();
-            System.out.println("Already loaded class: " + c.getName() + " (loader: " + classLoaderName + ")");
-//            System.out.println("Already loaded class: " + c.getName());
+            System.out.println("Already loaded class: " + c.getName() + " (loader: " + classLoaderName + ", modifiable=" + instrumentation.isModifiableClass(c) + ")");
         }
         System.out.println("End of list of already-loaded classes at agent start time.");
 

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -29,7 +29,7 @@ public class ProvenanceAgent {
 //            "java/sql"
     );
 
-    public static int DEBUG_testCrossAppCommunication = 43;     // 42 in installed version, 43 in freshly-built
+    public static int DEBUG_testCrossAppCommunication = 44;     // 42 in installed version
     private static ProvenanceTracker<Invocation> tracker;
 
     private ProvenanceAgent() {

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/instrumentation/ProvenanceAgent.java
@@ -23,6 +23,7 @@ public class ProvenanceAgent {
 //            "java/sql"
     );
 
+    public static int DEBUG_testCrossAppCommunication = 43;     // 42 in installed version, 43 in freshly-built
     private static ProvenanceTracker<Invocation> tracker;
 
     private ProvenanceAgent() {
@@ -54,6 +55,12 @@ public class ProvenanceAgent {
      * @param instrumentation instrumentation instance
      */
     private static void install(Instrumentation instrumentation) {
+        //DEBUG
+        System.out.println("Hello world from the ProvenanceAgent!");
+        System.out.println("(in ProvenanceAgent) DEBUG_testCrossAppCommunication=" + DEBUG_testCrossAppCommunication);
+//        System.out.println("jakarta.servlet.Filter.class.getClassLoader()=" + jakarta.servlet.Filter.class.getClassLoader());
+        printClassLoaderChain(ProvenanceAgent.class);
+
         // Construct cache to be used by instrumentation classes
         tracker = new ThreadLocalProvenanceTracker<Invocation>();
         AssociationCache cache = new AssociationCache(tracker);
@@ -84,5 +91,15 @@ public class ProvenanceAgent {
 
     public static ProvenanceTracker<Invocation> getProvenanceTracker() {
         return tracker;
+    }
+
+    //DEBUG
+    static void printClassLoaderChain(Class c) {
+        System.out.println("(Running inside ProvenanceAgent) ClassLoader chain for " + c + ":");
+        for (ClassLoader cl = c.getClassLoader(); cl != null; cl = cl.getClass().getClassLoader()) {
+            Class cc = cl.getClass();
+            System.out.println("loader=" + cl + ", class=" + cc + ", name=" + cc.getName() + ", canonicalName=" + cc.getCanonicalName() + ", simpleName=" + cc.getSimpleName() + ", typeName=" + cc.getTypeName());
+        }
+        System.out.println("(null, meaning the bootstrap ClassLoader)\nThe end.");
     }
 }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/GlobalProvenanceTracker.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/GlobalProvenanceTracker.java
@@ -19,26 +19,32 @@ public class GlobalProvenanceTracker implements ProvenanceTracker<Invocation> {
 
     @Override
     public String start() {
+        System.out.println("GlobalProvenanceTracker.start() called!");  //DEBUG
         return "global";
     }
 
     @Override
     public void finish() {
+        System.out.println("GlobalProvenanceTracker.finish() called! Will move " + invocations.size() + " invocations to outbox.");  //DEBUG
         outbox.addAll(this.invocations);
         invocations.clear();
     }
 
     public void track(Invocation invocation) {
+        System.out.println("GlobalProvenanceTracker.track(" + invocation + ") called!");  //DEBUG
         invocations.add(invocation);
+        System.out.println("GlobalProvenanceTracker.track(): There are now " + invocations.size() + " invocations tracked so far.");  //DEBUG
     }
 
     @Override
     public List<Invocation> pickup(String id) {
+        System.out.println("GlobalProvenanceTracker.pickup(" + id + ") called! Will send " + outbox.size() + " invocations back.");  //DEBUG
         return List.copyOf(outbox);     // Don't return the same list that cull() will clear out!
     }
 
     @Override
     public boolean cull(String id) {
+        System.out.println("GlobalProvenanceTracker.cull() called! Removing " + outbox.size() + " invocations from outbox.");  //DEBUG
         outbox.clear();
         return true;
     }

--- a/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
+++ b/src/main/java/nz/ac/wgtn/veracity/provenance/injector/tracker/ThreadLocalProvenanceTracker.java
@@ -34,6 +34,7 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
         }
 
         String generatedId = "" + ID_GENERATOR.incrementAndGet();
+        System.out.println("ThreadLocalProvenanceTracker.start() called! Returning id " + generatedId);  //DEBUG
         this.id.set(generatedId);
         this.trackedData.set(new ArrayList<>());
         return generatedId;
@@ -49,6 +50,7 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
      * TODO: There is currently no way to determine which threads have outstanding non-request invocations.
      */
     public void finish() {
+        System.out.println("ThreadLocalProvenanceTracker.finish() called for ID " + getNiceId() + "! Will move " + trackedData.get().size() + " invocations to outbox.");  //DEBUG
         this.outbox.put(getNiceId(), Collections.unmodifiableList(trackedData.get()));
         if (trackedData.get() == noActiveRequestTrackedData.get()) {
             // We are outside of any request.
@@ -66,7 +68,9 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
      * @param data
      */
     public void track(T data) {
+        System.out.println("ThreadLocalProvenanceTracker.track(" + data + ") called for ID " + getNiceId() + "!");  //DEBUG
         trackedData.get().add(data);
+        System.out.println("ThreadLocalProvenanceTracker.track(): There are now " + trackedData.get().size() + " invocations tracked so far for ID " + getNiceId() + ".");  //DEBUG
     }
 
     public List<T> pickup(String id) {
@@ -74,6 +78,7 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
         if (data==null) {
             throw new IllegalArgumentException("no data available for key " + id);
         }
+        System.out.println("ThreadLocalProvenanceTracker.pickup(" + id + ") called! Will send " + data.size() + " invocations back.");  //DEBUG
         return data;
     }
 
@@ -82,6 +87,7 @@ public class ThreadLocalProvenanceTracker<T> implements ProvenanceTracker<T> {
      * Return true if data was cleared, false otherwise.
      */
     public boolean cull(String id) {
+        System.out.println("ThreadLocalProvenanceTracker.cull(" + id + ") called! Removing " + (outbox.containsKey(id) ? "" + outbox.get(id).size() : "<NULL>") + " invocations from outbox.");  //DEBUG
         return outbox.remove(id)!=null;
     }
 

--- a/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/AssociationCacheTestCase.java
+++ b/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/AssociationCacheTestCase.java
@@ -1,5 +1,6 @@
-package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
+package nz.ac.wgtn.veracity.provenance.injector.testinstrumentation;
 
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.AssociationCache;
 import nz.ac.wgtn.veracity.provenance.injector.model.Entity;
 import nz.ac.wgtn.veracity.provenance.injector.tracker.NoopProvenanceTracker;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/EntityCreationTestCase.java
+++ b/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/EntityCreationTestCase.java
@@ -1,5 +1,7 @@
-package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
+package nz.ac.wgtn.veracity.provenance.injector.testinstrumentation;
 
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.AssociationCache;
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.AssociationCacheRegistry;
 import nz.ac.wgtn.veracity.provenance.injector.model.Entity;
 import nz.ac.wgtn.veracity.provenance.injector.sampleclasses.SomeClass;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/InvocationCreationTestCase.java
+++ b/src/test/java/nz/ac/wgtn/veracity/provenance/injector/testinstrumentation/InvocationCreationTestCase.java
@@ -1,5 +1,7 @@
-package nz.ac.wgtn.veracity.provenance.injector.instrumentation;
+package nz.ac.wgtn.veracity.provenance.injector.testinstrumentation;
 
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.AssociationCache;
+import nz.ac.wgtn.veracity.provenance.injector.instrumentation.AssociationCacheRegistry;
 import nz.ac.wgtn.veracity.provenance.injector.sampleclasses.SomeClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR brings in messy stuff that would be a pain to remove because doing so would cause lots of merge conflicts with future work (e.g. the `entity-creation-this` branch) even though the latter mostly doesn't depend on it:

- Ignore `java.net.URLClassLoader` specifically to get around the `NoClassDefFoundError` problem of https://github.com/veracitylab/provenance-injector/issues/25#issue-2318159921.
- Also add most of our own packages to `ignorePackages` to help against this class of problems.
- Renaming the package `nz.ac.wgtn.veracity.provenance.injector.instrumentation` to `nz.ac.wgtn.veracity.provenance.injector.testinstrumentation` (which *isn't* in `ignorePackages`) to enable unit tests to still work despite the above. This also forced many things to become `public`, since the tests are now in a different package and thus lose their special access.
- Lots of debug logging.

Some of these changes may be removed in a separate PR later.
